### PR TITLE
Updated the description of byte buffers.

### DIFF
--- a/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ConnectionAttributeStore.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ConnectionAttributeStore.java
@@ -90,8 +90,8 @@ public interface ConnectionAttributeStore {
     /**
      * Retrieves the value of the connection attribute with the given key for the connected client.
      * <p>
-     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
-     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a {@link
+     * java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @param key The key of the connection attribute.
      * @return An {@link Optional} containing the value of the connection attribute if present.
@@ -115,14 +115,14 @@ public interface ConnectionAttributeStore {
      * @param key     The key of the connection attribute.
      * @param charset The {@link Charset} of the value of the connection attribute.
      * @return An {@link Optional} containing the value of the connection attribute as a string with the given charset
-     * if present.
+     *         if present.
      * @since 4.0.0, CE 2019.1
      */
     @NotNull Optional<String> getAsString(@NotNull String key, @NotNull Charset charset);
 
     /**
      * Retrieves all connection attributes for the connected client.
-     *
+     * <p>
      * The ByteBuffers returned by this method are {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
      * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
@@ -134,8 +134,8 @@ public interface ConnectionAttributeStore {
     /**
      * Removes the connection attribute with the given key for the connected client.
      * <p>
-     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
-     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a {@link
+     * java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @param key The key of the connection attribute.
      * @return An {@link Optional} containing the value of the removed connection attribute if it was present.

--- a/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ConnectionAttributeStore.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ConnectionAttributeStore.java
@@ -17,6 +17,7 @@
 package com.hivemq.extension.sdk.api.client.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
+import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.ThreadSafe;
 import com.hivemq.extension.sdk.api.services.exception.LimitExceededException;
@@ -88,12 +89,15 @@ public interface ConnectionAttributeStore {
 
     /**
      * Retrieves the value of the connection attribute with the given key for the connected client.
+     * <p>
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
+     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @param key The key of the connection attribute.
      * @return An {@link Optional} containing the value of the connection attribute if present.
      * @since 4.0.0, CE 2019.1
      */
-    @NotNull Optional<ByteBuffer> get(@NotNull String key);
+    @NotNull Optional<@Immutable ByteBuffer> get(@NotNull String key);
 
     /**
      * Retrieves the value of the connection attribute with the given key for the connected client as UTF-8 string.
@@ -111,7 +115,7 @@ public interface ConnectionAttributeStore {
      * @param key     The key of the connection attribute.
      * @param charset The {@link Charset} of the value of the connection attribute.
      * @return An {@link Optional} containing the value of the connection attribute as a string with the given charset
-     *         if present.
+     * if present.
      * @since 4.0.0, CE 2019.1
      */
     @NotNull Optional<String> getAsString(@NotNull String key, @NotNull Charset charset);
@@ -119,19 +123,25 @@ public interface ConnectionAttributeStore {
     /**
      * Retrieves all connection attributes for the connected client.
      *
+     * The ByteBuffers returned by this method are {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
+     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
+     *
      * @return An {@link Optional} containing all connection attributes as a map of key and value pairs if present.
      * @since 4.0.0, CE 2019.1
      */
-    @NotNull Optional<Map<String, ByteBuffer>> getAll();
+    @NotNull Optional<Map<String, @Immutable ByteBuffer>> getAll();
 
     /**
      * Removes the connection attribute with the given key for the connected client.
+     * <p>
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
+     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @param key The key of the connection attribute.
      * @return An {@link Optional} containing the value of the removed connection attribute if it was present.
      * @since 4.0.0, CE 2019.1
      */
-    @NotNull Optional<ByteBuffer> remove(@NotNull String key);
+    @NotNull Optional<@Immutable ByteBuffer> remove(@NotNull String key);
 
     /**
      * Clears all connection attributes for the connected client.

--- a/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ProxyInformation.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ProxyInformation.java
@@ -17,6 +17,7 @@
 package com.hivemq.extension.sdk.api.client.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
+import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 
 import java.net.InetAddress;
@@ -85,9 +86,12 @@ public interface ProxyInformation {
      * raw TLVs that are sent by the load balancer.
      * <p>
      * The key is the byte value of the TLV type and the value is the raw TLV as byte value.
+     * <p>
+     * The ByteBuffers returned by this method are {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
+     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return A {@link Map} with raw TLVs.
      * @since 4.0.0, CE 2019.1
      */
-    @NotNull Map<Byte, ByteBuffer> getRawTLVs();
+    @NotNull Map<Byte, @Immutable ByteBuffer> getRawTLVs();
 }

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/auth/AuthPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/auth/AuthPacket.java
@@ -45,8 +45,8 @@ public interface AuthPacket {
     /**
      * The optional authentication data of the AUTH packet.
      * <p>
-     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
-     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a {@link
+     * java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} containing the authentication data if present.
      * @since 4.3.0, CE 2020.1

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/auth/AuthPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/auth/AuthPacket.java
@@ -44,11 +44,14 @@ public interface AuthPacket {
 
     /**
      * The optional authentication data of the AUTH packet.
+     * <p>
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
+     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} containing the authentication data if present.
      * @since 4.3.0, CE 2020.1
      */
-    @NotNull Optional<ByteBuffer> getAuthenticationData();
+    @NotNull Optional<@Immutable ByteBuffer> getAuthenticationData();
 
     /**
      * The optional authentication data of the AUTH packet as a byte array.

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/connack/ConnackPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/connack/ConnackPacket.java
@@ -16,6 +16,7 @@
 
 package com.hivemq.extension.sdk.api.packets.connack;
 
+import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.packets.connect.ConnackReasonCode;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
@@ -223,9 +224,12 @@ public interface ConnackPacket {
      * contents of this data are defined by the authentication method.
      * <p>
      * For an MQTT 3 client this {@link Optional} for the MQTT 5 property will always be empty.
+     * <p>
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
+     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the authentication data if present.
      * @since 4.2.0, CE 2020.1
      */
-    @NotNull Optional<ByteBuffer> getAuthenticationData();
+    @NotNull Optional<@Immutable ByteBuffer> getAuthenticationData();
 }

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/connack/ConnackPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/connack/ConnackPacket.java
@@ -225,8 +225,8 @@ public interface ConnackPacket {
      * <p>
      * For an MQTT 3 client this {@link Optional} for the MQTT 5 property will always be empty.
      * <p>
-     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
-     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a {@link
+     * java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the authentication data if present.
      * @since 4.2.0, CE 2020.1

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
@@ -171,11 +171,14 @@ public interface ConnectPacket {
      * contents of this data are defined by the authentication method.
      * <p>
      * For an MQTT 3 client this property can be set in the {@link ConnectInboundInterceptor}.
+     * <p>
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
+     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the authentication data if present.
      * @since 4.0.0, CE 2019.1
      */
-    @NotNull Optional<ByteBuffer> getAuthenticationData();
+    @NotNull Optional<@Immutable ByteBuffer> getAuthenticationData();
 
     /**
      * The user properties from the CONNECT packet.
@@ -197,9 +200,12 @@ public interface ConnectPacket {
 
     /**
      * If this property is present, this is the password for the client.
+     * <p>
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
+     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the password if present.
      * @since 4.0.0, CE 2019.1
      */
-    @NotNull Optional<ByteBuffer> getPassword();
+    @NotNull Optional<@Immutable ByteBuffer> getPassword();
 }

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
@@ -172,8 +172,8 @@ public interface ConnectPacket {
      * <p>
      * For an MQTT 3 client this property can be set in the {@link ConnectInboundInterceptor}.
      * <p>
-     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
-     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a {@link
+     * java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the authentication data if present.
      * @since 4.0.0, CE 2019.1
@@ -201,8 +201,8 @@ public interface ConnectPacket {
     /**
      * If this property is present, this is the password for the client.
      * <p>
-     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
-     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a {@link
+     * java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the password if present.
      * @since 4.0.0, CE 2019.1

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
@@ -114,6 +114,9 @@ public interface PublishPacket {
      * If this property is present, this is the correlation data.
      * <p>
      * For an MQTT 3 PUBLISH this MQTT 5 property will always be empty.
+     * <p>
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
+     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the correlation data if present.
      * @since 4.0.0, CE 2019.1
@@ -142,6 +145,9 @@ public interface PublishPacket {
 
     /**
      * If this property is present, this is the payload.
+     * <p>
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
+     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the payload if present.
      * @since 4.0.0, CE 2019.1

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
@@ -115,8 +115,8 @@ public interface PublishPacket {
      * <p>
      * For an MQTT 3 PUBLISH this MQTT 5 property will always be empty.
      * <p>
-     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
-     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a {@link
+     * java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the correlation data if present.
      * @since 4.0.0, CE 2019.1
@@ -146,8 +146,8 @@ public interface PublishPacket {
     /**
      * If this property is present, this is the payload.
      * <p>
-     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
-     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a {@link
+     * java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the payload if present.
      * @since 4.0.0, CE 2019.1

--- a/src/main/java/com/hivemq/extension/sdk/api/services/exception/IncompatibleHiveMQVersionException.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/exception/IncompatibleHiveMQVersionException.java
@@ -32,5 +32,6 @@ public class IncompatibleHiveMQVersionException extends Exception {
         INSTANCE.setStackTrace(new StackTraceElement[0]);
     }
 
-    private IncompatibleHiveMQVersionException() {}
+    private IncompatibleHiveMQVersionException() {
+    }
 }

--- a/src/main/java/com/hivemq/extension/sdk/api/services/publish/Publish.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/publish/Publish.java
@@ -97,6 +97,9 @@ public interface Publish {
 
     /**
      * If this property is present, this is the correlation data.
+     * <p>
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
+     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the correlation data if present.
      * @since 4.0.0, CE 2019.1
@@ -113,6 +116,9 @@ public interface Publish {
 
     /**
      * If this property is present, this is the payload.
+     * <p>
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
+     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the payload if present.
      * @since 4.0.0, CE 2019.1

--- a/src/main/java/com/hivemq/extension/sdk/api/services/publish/Publish.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/publish/Publish.java
@@ -98,8 +98,8 @@ public interface Publish {
     /**
      * If this property is present, this is the correlation data.
      * <p>
-     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
-     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a {@link
+     * java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the correlation data if present.
      * @since 4.0.0, CE 2019.1
@@ -117,8 +117,8 @@ public interface Publish {
     /**
      * If this property is present, this is the payload.
      * <p>
-     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a
-     * {@link java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
+     * The ByteBuffer returned by this method is {@link ByteBuffer#asReadOnlyBuffer() read only} and will throw a {@link
+     * java.nio.ReadOnlyBufferException ReadOnlyBufferException} if handled incorrectly.
      *
      * @return An {@link Optional} that contains the payload if present.
      * @since 4.0.0, CE 2019.1

--- a/src/main/java/com/hivemq/extension/sdk/api/services/publish/PublishToClientResult.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/publish/PublishToClientResult.java
@@ -24,7 +24,7 @@ package com.hivemq.extension.sdk.api.services.publish;
  */
 public enum PublishToClientResult {
 
-     /**
+    /**
      * The client had a matching subscription.
      *
      * @since 4.0.0, CE 2019.1


### PR DESCRIPTION
**Motivation**

ByteBuffers are notoriously easy to misuse. Warnings to avoid issues should be in place.

**Changes**

Noted the read only nature of returned ByteBuffers where it was missing.
