### PR TITLE
Feature/id 219 iterate all retained messages

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=4.3.0
+version=4.4.0-SNAPSHOT
 #
 # main dependencies
 #

--- a/src/main/java/com/hivemq/extension/sdk/api/services/publish/Publish.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/publish/Publish.java
@@ -44,6 +44,7 @@ public interface Publish {
      * @since 4.0.0, CE 2019.1
      * @deprecated Use {@link Builders#publish()} instead
      */
+    @Deprecated(since = "4.4.0")
     static PublishBuilder builder() {
         return Builders.publish();
     }

--- a/src/main/java/com/hivemq/extension/sdk/api/services/publish/Publish.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/publish/Publish.java
@@ -42,6 +42,7 @@ public interface Publish {
     /**
      * @return A new {@link PublishBuilder} to create a {@link Publish}.
      * @since 4.0.0, CE 2019.1
+     * @deprecated Use {@link Builders#publish()} instead
      */
     static PublishBuilder builder() {
         return Builders.publish();

--- a/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedMessageStore.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedMessageStore.java
@@ -121,7 +121,7 @@ public interface RetainedMessageStore {
      * @param callback An {@link IterationCallback} that is called for every returned result.
      * @return A {@link CompletableFuture} that is completed after all iterations are executed, no match is found or the
      * iteration is aborted manually with the {@link IterationContext}.
-     * @throws NullPointerException If the passed callback is null.
+     * @throws NullPointerException if the passed callback is null.
      * @since 4.4.0, CE 2020.4
      */
     @NotNull CompletableFuture<Void> iterateAllRetainedMessages(@NotNull IterationCallback<RetainedPublish> callback);
@@ -155,7 +155,7 @@ public interface RetainedMessageStore {
      * @param callbackExecutor An {@link Executor} that the {@link IterationCallback} is executed in.
      * @return A {@link CompletableFuture} that is completed after all iterations are executed, no match is found or the
      * iteration is aborted manually with the {@link IterationContext}.
-     * @throws NullPointerException If the passed callback or callbackExecutor are null.
+     * @throws NullPointerException if the passed callback or callbackExecutor are null.
      * @since 4.4.0, CE 2020.4
      */
     @NotNull CompletableFuture<Void> iterateAllRetainedMessages(

--- a/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedMessageStore.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedMessageStore.java
@@ -18,11 +18,17 @@ package com.hivemq.extension.sdk.api.services.publish;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.services.ManagedExtensionExecutorService;
 import com.hivemq.extension.sdk.api.services.exception.DoNotImplementException;
+import com.hivemq.extension.sdk.api.services.exception.IncompatibleHiveMQVersionException;
+import com.hivemq.extension.sdk.api.services.exception.IterationFailedException;
 import com.hivemq.extension.sdk.api.services.exception.RateLimitExceededException;
+import com.hivemq.extension.sdk.api.services.general.IterationCallback;
+import com.hivemq.extension.sdk.api.services.general.IterationContext;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * The retained message store allows the management of retained messages from within extensions.
@@ -85,4 +91,72 @@ public interface RetainedMessageStore {
      * @since 4.0.0, CE 2019.1
      */
     @NotNull CompletableFuture<Void> addOrReplace(@NotNull RetainedPublish retainedPublish);
+
+    /**
+     * Iterate over all retained messages.
+     * <p>
+     * The callback is called once for each retained message. Passed to each execution of the callback is all
+     * information about the retained message, such as its payload and its metadata. Retained messages that have
+     * exceeded their message expiry interval are not included.
+     * <p>
+     * The callback is executed in the {@link ManagedExtensionExecutorService} per default. Use the overloaded methods
+     * to pass a custom executor for the callback. If you want to collect the results of each execution of the callback
+     * in a collection please make sure to use a concurrent collection (thread-safe), as the callback might be executed
+     * in another thread as the calling thread of this method.
+     * <p>
+     * The results are not sorted in any way, no ordering of any kind is guaranteed.
+     * <p>
+     * CAUTION: This method can be used in large scale deployments, but it is a very expensive operation. Do not call
+     * this method in short time intervals.
+     * <p>
+     * If you are searching for a specific entry in the results and have found what you are looking for, you can abort
+     * further iteration and save resources by calling {@link IterationContext#abortIteration()}.
+     * <p>
+     * {@link CompletableFuture} fails with an {@link IncompatibleHiveMQVersionException} if not all HiveMQ nodes in the
+     * cluster have at least version 4.4.0. {@link CompletableFuture} fails with a {@link RateLimitExceededException} if
+     * the extension service rate limit was exceeded. {@link CompletableFuture} fails with a {@link
+     * IterationFailedException} if the cluster topology changed during the iteration (e.g. a network-split, node leave
+     * or node join)
+     *
+     * @param callback An {@link IterationCallback} that is called for every returned result.
+     * @return A {@link CompletableFuture} that is completed after all iterations are executed, no match is found or the
+     *         iteration is aborted manually with the {@link IterationContext}.
+     * @throws NullPointerException If the passed callback is null.
+     * @since 4.4.0, CE 2020.3
+     */
+    @NotNull CompletableFuture<Void> iterateAllRetainedMessages(@NotNull IterationCallback<RetainedPublish> callback);
+
+    /**
+     * Iterate over all retained messages.
+     * <p>
+     * The callback is called once for each retained message. Passed to each execution of the callback is all
+     * information about the retained message, such as its payload and its metadata. Retained messages that have
+     * exceeded their message expiry interval are not included.
+     * <p>
+     * The callback is executed in the passed {@link Executor}. If you want to collect the results of each execution of
+     * the callback in a collection please make sure to use a concurrent collection (thread-safe), as the callback might
+     * be executed in another thread as the calling thread of this method.
+     * <p>
+     * The results are not sorted in any way, no ordering of any kind is guaranteed.
+     * <p>
+     * CAUTION: This method can be used in large scale deployments, but it is a very expensive operation. Do not call
+     * this method in short time intervals.
+     * <p>
+     * If you are searching for a specific entry in the results and have found what you are looking for, you can abort
+     * further iteration and save resources by calling {@link IterationContext#abortIteration()}.
+     * <p>
+     * {@link CompletableFuture} fails with an {@link IncompatibleHiveMQVersionException} if not all HiveMQ nodes in the
+     * cluster have at least version 4.4.0. {@link CompletableFuture} fails with a {@link RateLimitExceededException} if
+     * the extension service rate limit was exceeded. {@link CompletableFuture} fails with a {@link
+     * IterationFailedException} if the cluster topology changed during the iteration (e.g. a network-split, node leave
+     * or node join)
+     *
+     * @param callback An {@link IterationCallback} that is called for every returned result.
+     * @return A {@link CompletableFuture} that is completed after all iterations are executed, no match is found or the
+     *         iteration is aborted manually with the {@link IterationContext}.
+     * @throws NullPointerException If the passed callback or callbackExecutor are null.
+     * @since 4.4.0, CE 2020.3
+     */
+    @NotNull CompletableFuture<Void> iterateAllRetainedMessages(
+            @NotNull IterationCallback<RetainedPublish> callback, Executor callbackExecutor);
 }

--- a/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedMessageStore.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedMessageStore.java
@@ -93,7 +93,7 @@ public interface RetainedMessageStore {
     @NotNull CompletableFuture<Void> addOrReplace(@NotNull RetainedPublish retainedPublish);
 
     /**
-     * Iterate over all retained messages.
+     * Iterate over all retained messages in the HiveMQ cluster.
      * <p>
      * The callback is called once for each retained message. Passed to each execution of the callback is all
      * information about the retained message, such as its payload and its metadata. Retained messages that have
@@ -127,7 +127,7 @@ public interface RetainedMessageStore {
     @NotNull CompletableFuture<Void> iterateAllRetainedMessages(@NotNull IterationCallback<RetainedPublish> callback);
 
     /**
-     * Iterate over all retained messages.
+     * Iterate over all retained messages in the HiveMQ cluster.
      * <p>
      * The callback is called once for each retained message. Passed to each execution of the callback is all
      * information about the retained message, such as its payload and its metadata. Retained messages that have

--- a/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedMessageStore.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedMessageStore.java
@@ -122,7 +122,7 @@ public interface RetainedMessageStore {
      * @return A {@link CompletableFuture} that is completed after all iterations are executed, no match is found or the
      *         iteration is aborted manually with the {@link IterationContext}.
      * @throws NullPointerException If the passed callback is null.
-     * @since 4.4.0, CE 2020.3
+     * @since 4.4.0, CE 2020.4
      */
     @NotNull CompletableFuture<Void> iterateAllRetainedMessages(@NotNull IterationCallback<RetainedPublish> callback);
 
@@ -152,10 +152,11 @@ public interface RetainedMessageStore {
      * or node join)
      *
      * @param callback An {@link IterationCallback} that is called for every returned result.
+     * @param callbackExecutor An {@link Executor} that the {@link IterationCallback} is executed in.
      * @return A {@link CompletableFuture} that is completed after all iterations are executed, no match is found or the
      *         iteration is aborted manually with the {@link IterationContext}.
      * @throws NullPointerException If the passed callback or callbackExecutor are null.
-     * @since 4.4.0, CE 2020.3
+     * @since 4.4.0, CE 2020.4
      */
     @NotNull CompletableFuture<Void> iterateAllRetainedMessages(
             @NotNull IterationCallback<RetainedPublish> callback, Executor callbackExecutor);

--- a/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedMessageStore.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedMessageStore.java
@@ -48,7 +48,7 @@ public interface RetainedMessageStore {
      *
      * @param topic The topic.
      * @return A {@link CompletableFuture} which contains the retained message for the specific topic or
-     *         <code>null</code>.
+     * <code>null</code>.
      * @since 4.0.0, CE 2019.1
      */
     @NotNull CompletableFuture<Optional<RetainedPublish>> getRetainedMessage(@NotNull String topic);
@@ -120,7 +120,7 @@ public interface RetainedMessageStore {
      *
      * @param callback An {@link IterationCallback} that is called for every returned result.
      * @return A {@link CompletableFuture} that is completed after all iterations are executed, no match is found or the
-     *         iteration is aborted manually with the {@link IterationContext}.
+     * iteration is aborted manually with the {@link IterationContext}.
      * @throws NullPointerException If the passed callback is null.
      * @since 4.4.0, CE 2020.4
      */
@@ -151,13 +151,13 @@ public interface RetainedMessageStore {
      * IterationFailedException} if the cluster topology changed during the iteration (e.g. a network-split, node leave
      * or node join)
      *
-     * @param callback An {@link IterationCallback} that is called for every returned result.
+     * @param callback         An {@link IterationCallback} that is called for every returned result.
      * @param callbackExecutor An {@link Executor} that the {@link IterationCallback} is executed in.
      * @return A {@link CompletableFuture} that is completed after all iterations are executed, no match is found or the
-     *         iteration is aborted manually with the {@link IterationContext}.
+     * iteration is aborted manually with the {@link IterationContext}.
      * @throws NullPointerException If the passed callback or callbackExecutor are null.
      * @since 4.4.0, CE 2020.4
      */
     @NotNull CompletableFuture<Void> iterateAllRetainedMessages(
-            @NotNull IterationCallback<RetainedPublish> callback, Executor callbackExecutor);
+            @NotNull IterationCallback<RetainedPublish> callback, @NotNull Executor callbackExecutor);
 }

--- a/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedPublish.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedPublish.java
@@ -31,6 +31,7 @@ public interface RetainedPublish extends Publish {
     /**
      * @return A new {@link RetainedPublishBuilder} to create a retained publish.
      * @since 4.0.0, CE 2019.1
+     * @deprecated Use {@link Builders#retainedPublish()} instead
      */
     static @NotNull RetainedPublishBuilder builder() {
         return Builders.retainedPublish();

--- a/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedPublish.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedPublish.java
@@ -33,6 +33,7 @@ public interface RetainedPublish extends Publish {
      * @since 4.0.0, CE 2019.1
      * @deprecated Use {@link Builders#retainedPublish()} instead
      */
+    @Deprecated(since = "4.4.0")
     static @NotNull RetainedPublishBuilder builder() {
         return Builders.retainedPublish();
     }

--- a/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
@@ -186,7 +186,7 @@ public interface ClientService {
      * @param callback An {@link IterationCallback} that is called for every returned result.
      * @return A {@link CompletableFuture} that is completed after all iterations are executed, no match is found or the
      *         iteration is aborted manually with the {@link IterationContext}.
-     * @throws NullPointerException If the passed callback or callbackExecutor are null.
+     * @throws NullPointerException If the passed callback is null.
      * @since 4.2.0, CE 2020.1
      */
     @NotNull CompletableFuture<Void> iterateAllClients(@NotNull IterationCallback<SessionInformation> callback);

--- a/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
@@ -159,7 +159,7 @@ public interface ClientService {
     @NotNull CompletableFuture<Boolean> invalidateSession(@NotNull String clientId);
 
     /**
-     * Iterate over all clients and their session information.
+     * Iterate over all clients and their session information in the HiveMQ cluster.
      * <p>
      * The callback is called once for each client. Passed to each execution of the callback are the client identifier
      * and its session information. Clients that have exceeded their session expiry interval are not included.
@@ -192,7 +192,7 @@ public interface ClientService {
     @NotNull CompletableFuture<Void> iterateAllClients(@NotNull IterationCallback<SessionInformation> callback);
 
     /**
-     * Iterate over all clients and their session information.
+     * Iterate over all clients and their session information in the HiveMQ cluster.
      * <p>
      * The callback is called once for each client. Passed to each execution of the callback are the client identifier
      * and its session information. Clients that have exceeded their session expiry interval are not included.

--- a/src/main/java/com/hivemq/extension/sdk/api/services/subscription/SubscriptionStore.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/subscription/SubscriptionStore.java
@@ -138,7 +138,7 @@ public interface SubscriptionStore {
     @NotNull CompletableFuture<Set<TopicSubscription>> getSubscriptions(@NotNull String clientID);
 
     /**
-     * Iterate over all subscribers that have a subscription that matches the passed topic. Includes subscribers with
+     * Iterate over all subscribers in the HiveMQ cluster that have a subscription that matches the passed topic. Includes subscribers with
      * direct matches of the topic or a match via a wildcard topic.
      * <p>
      * Example: For topic <code>example/topic</code> we would iterate over all clients with a subscription for
@@ -177,7 +177,7 @@ public interface SubscriptionStore {
             @NotNull String topic, @NotNull IterationCallback<SubscriberForTopicResult> callback);
 
     /**
-     * Iterate over all subscribers that have a subscription that matches the passed topic. Includes subscribers with
+     * Iterate over all subscribers in the HiveMQ cluster that have a subscription that matches the passed topic. Includes subscribers with
      * direct matches of the topic or a match via a wildcard topic.
      * <p>
      * Example: For topic <code>example/topic</code> we would iterate over all clients with a subscription for
@@ -218,7 +218,7 @@ public interface SubscriptionStore {
             @NotNull IterationCallback<SubscriberForTopicResult> callback);
 
     /**
-     * Iterate over all subscribers that have a subscription that matches the passed topic. Includes subscribers with
+     * Iterate over all subscribers in the HiveMQ cluster that have a subscription that matches the passed topic. Includes subscribers with
      * direct matches of the topic or a match via a wildcard topic.
      * <p>
      * Example: For topic <code>example/topic</code> we would iterate over all clients with a subscription for
@@ -259,7 +259,7 @@ public interface SubscriptionStore {
             @NotNull Executor callbackExecutor);
 
     /**
-     * Iterate over all subscribers that have a subscription that matches the passed topic. Includes subscribers with
+     * Iterate over all subscribers in the HiveMQ cluster that have a subscription that matches the passed topic. Includes subscribers with
      * direct matches of the topic or a match via a wildcard topic.
      * <p>
      * Example: For topic <code>example/topic</code> we would iterate over all clients with a subscription for
@@ -301,7 +301,7 @@ public interface SubscriptionStore {
             @NotNull Executor callbackExecutor);
 
     /**
-     * Iterate over all subscribers that have a subscription that equals the passed topic filter. Only includes
+     * Iterate over all subscribers in the HiveMQ cluster that have a subscription that equals the passed topic filter. Only includes
      * subscribers with direct matches of the topic.
      * <p>
      * Example 1: For topic filter <code>example/topic</code> we would iterate over all clients with a subscription for
@@ -345,7 +345,7 @@ public interface SubscriptionStore {
             @NotNull String topicFilter, @NotNull IterationCallback<SubscriberWithFilterResult> callback);
 
     /**
-     * Iterate over all subscribers that have a subscription that equals the passed topic filter. Only includes
+     * Iterate over all subscribers in the HiveMQ cluster that have a subscription that equals the passed topic filter. Only includes
      * subscribers with direct matches of the topic.
      * <p>
      * Example 1: For topic filter <code>example/topic</code> we would iterate over all clients with a subscription for
@@ -391,7 +391,7 @@ public interface SubscriptionStore {
             @NotNull IterationCallback<SubscriberWithFilterResult> callback);
 
     /**
-     * Iterate over all subscribers that have a subscription that equals the passed topic filter. Only includes
+     * Iterate over all subscribers in the HiveMQ cluster that have a subscription that equals the passed topic filter. Only includes
      * subscribers with direct matches of the topic.
      * <p>
      * Example 1: For topic filter <code>example/topic</code> we would iterate over all clients with a subscription for
@@ -437,7 +437,7 @@ public interface SubscriptionStore {
             @NotNull Executor callbackExecutor);
 
     /**
-     * Iterate over all subscribers that have a subscription that equals the passed topic filter. Only includes
+     * Iterate over all subscribers in the HiveMQ cluster that have a subscription that equals the passed topic filter. Only includes
      * subscribers with direct matches of the topic.
      * <p>
      * Example 1: For topic filter <code>example/topic</code> we would iterate over all clients with a subscription for
@@ -485,7 +485,7 @@ public interface SubscriptionStore {
             @NotNull Executor callbackExecutor);
 
     /**
-     * Iterate over all subscribers and their subscriptions.
+     * Iterate over all subscribers and their subscriptions in the HiveMQ cluster.
      * <p>
      * The callback is called once for each client. Passed to each execution of the callback are the client identifier
      * and a set of all its subscriptions. Clients without subscriptions are not included.
@@ -519,7 +519,7 @@ public interface SubscriptionStore {
             @NotNull IterationCallback<SubscriptionsForClientResult> callback);
 
     /**
-     * Iterate over all subscribers and their subscriptions.
+     * Iterate over all subscribers and their subscriptions in the HiveMQ cluster.
      * <p>
      * The callback is called once for each client. Passed to each execution of the callback are the client identifier
      * and a set of all its subscriptions. Clients without subscriptions are not included.

--- a/src/main/java/com/hivemq/extension/sdk/api/services/subscription/TopicSubscription.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/subscription/TopicSubscription.java
@@ -41,6 +41,7 @@ public interface TopicSubscription {
     /**
      * @return A new {@link TopicSubscriptionBuilder} to create a topic subscription.
      * @since 4.0.0, CE 2019.1
+     * @deprecated Use {@link Builders#topicSubscription()} instead
      */
     static TopicSubscriptionBuilder builder() {
         return Builders.topicSubscription();

--- a/src/main/java/com/hivemq/extension/sdk/api/services/subscription/TopicSubscription.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/services/subscription/TopicSubscription.java
@@ -43,6 +43,7 @@ public interface TopicSubscription {
      * @since 4.0.0, CE 2019.1
      * @deprecated Use {@link Builders#topicSubscription()} instead
      */
+    @Deprecated(since = "4.4.0")
     static TopicSubscriptionBuilder builder() {
         return Builders.topicSubscription();
     }


### PR DESCRIPTION
**Motivation**

Add a way to iterate all retained messages currently in the system.

**Changes**

* Added two methods to the RetainedMessageStore, that allow to iterate all retained messages.
* Deprecated the inlined builder methods for extension objects