### PR TITLE
Feature/Add arrival timestamp to PublishPacket in SDK

### DIFF
--- a/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
@@ -52,8 +52,8 @@ public interface WillPublishPacket extends PublishPacket {
     /**
      * The timestamp when the CONNECT packet with the Will Publish arrived at the broker.
      * <p>
-     * When the Will Publish is sent to subscribers (after the client disconnects ungracefully and the Will delay has
-     * passed) the created PUBLISH packet will carry the timestamp of the delivery start.
+     * When the Will Publish is sent to subscribers (after the client disconnected ungracefully and the Will delay has passed)
+     * the created PUBLISH packet will carry the timestamp that represents the moment when the delivery started.
      * <p>
      * The returned timestamp is a UNIX timestamp since midnight, January 1, 1970 UTC in milliseconds.
      *

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
@@ -50,11 +50,15 @@ public interface WillPublishPacket extends PublishPacket {
     long getWillDelay();
 
     /**
-     * The arrival timestamp of the will publish.
+     * The creation timestamp of the Will Publish.
      * <p>
      * For a will publish the timestamp is set to the moment that the CONNECT message arrived at the broker.
      * <p>
-     * The returned timestamp is a UNIX timestamp since midnight, January 1, 1970 UTC in milliseconds
+     * The timestamp in the Will Publish packet that is sent to subscribers after the client disconnects is set to the
+     * moment when the Will Publish is triggered. The Will Publish is triggered after a client disconnects and the will
+     * delay is exceeded.
+     * <p>
+     * The returned timestamp is a UNIX timestamp since midnight, January 1, 1970 UTC in milliseconds.
      *
      * @return The timestamp.
      * @since 4.4.0, CE 2020.4

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
@@ -48,4 +48,17 @@ public interface WillPublishPacket extends PublishPacket {
      * @since 4.0.0, CE 2019.1
      */
     long getWillDelay();
+
+    /**
+     * The arrival timestamp of the will publish.
+     * <p>
+     * For a will publish the timestamp is set to the moment that the CONNECT message arrived at the broker.
+     * <p>
+     * The returned timestamp is a UNIX timestamp since midnight, January 1, 1970 UTC in milliseconds
+     *
+     * @return The timestamp.
+     * @since 4.4.0, CE 2020.4
+     */
+    @Override
+    long getTimestamp();
 }

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
@@ -54,8 +54,8 @@ public interface WillPublishPacket extends PublishPacket {
      * <p>
      * For a will publish the timestamp is set to the moment that the CONNECT message arrived at the broker.
      * <p>
-     * When the Will Publish is sent to subscribers (after the client disconnects ungracefully and the Will delay has passed)
-     * the created PUBLISH packet will carry the timestamp of the delivery start.
+     * When the Will Publish is sent to subscribers (after the client disconnects ungracefully and the Will delay has
+     * passed) the created PUBLISH packet will carry the timestamp of the delivery start.
      * <p>
      * The returned timestamp is a UNIX timestamp since midnight, January 1, 1970 UTC in milliseconds.
      *

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
@@ -54,9 +54,8 @@ public interface WillPublishPacket extends PublishPacket {
      * <p>
      * For a will publish the timestamp is set to the moment that the CONNECT message arrived at the broker.
      * <p>
-     * The timestamp in the Will Publish packet that is sent to subscribers after the client disconnects is set to the
-     * moment when the Will Publish is triggered. The Will Publish is triggered after a client disconnects and the will
-     * delay is exceeded.
+     * When the Will Publish is sent to subscribers (after the client disconnects ungracefully and the Will delay has passed)
+     * the created PUBLISH packet will carry the timestamp of the delivery start.
      * <p>
      * The returned timestamp is a UNIX timestamp since midnight, January 1, 1970 UTC in milliseconds.
      *

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
@@ -50,9 +50,7 @@ public interface WillPublishPacket extends PublishPacket {
     long getWillDelay();
 
     /**
-     * The creation timestamp of the Will Publish.
-     * <p>
-     * For a will publish the timestamp is set to the moment that the CONNECT message arrived at the broker.
+     * The timestamp when the CONNECT packet with the Will Publish arrived at the broker.
      * <p>
      * When the Will Publish is sent to subscribers (after the client disconnects ungracefully and the Will delay has
      * passed) the created PUBLISH packet will carry the timestamp of the delivery start.

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
@@ -167,9 +167,12 @@ public interface PublishPacket {
     /**
      * The arrival timestamp of the PUBLISH.
      * <p>
-     * For an incoming PUBLISH message the timestamp is set to the moment that the message arrived at the broker.
-     * For a message created via the Extension SDK the timestamp is set to the moment that the message is passed to
-     * PublishService.
+     * For an incoming PUBLISH message the timestamp represents the moment when the message arrived at the broker.
+     * For a message created via the Extension SDK the timestamp represents the moment when the message is passed to
+     * the PublishService.
+     * <p>
+     * For a Will Publish that is sent to subscribers, the timestamp represents the moment when the delivery started
+     * (after the client disconnected ungracefully and the Will delay has passed).
      * <p>
      * The returned timestamp is a UNIX timestamp since midnight, January 1, 1970 UTC in milliseconds.
      *

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
@@ -173,7 +173,7 @@ public interface PublishPacket {
      * The returned timestamp is a UNIX timestamp since midnight, January 1, 1970 UTC in milliseconds
      *
      * @return The timestamp.
-     * @since 4.4.0
+     * @since 4.4.0, CE 2020.4
      */
     long getTimestamp();
 }

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
@@ -163,4 +163,17 @@ public interface PublishPacket {
      * @since 4.0.0, CE 2019.1
      */
     @Immutable @NotNull UserProperties getUserProperties();
+
+    /**
+     * The arrival timestamp of the PUBLISH.
+     * <p>
+     * For an incoming PUBLISH message the timestamp is set to the moment that the message arrived at the broker.
+     * For a message created via the Extension SDK the timestamp is set to the moment that the message is passed to PublishService.
+     * <p>
+     * The returned timestamp is a UNIX timestamp since midnight, January 1, 1970 UTC in milliseconds
+     *
+     * @return The timestamp.
+     * @since 4.4.0
+     */
+    long getTimestamp();
 }

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
@@ -168,6 +168,7 @@ public interface PublishPacket {
      * The arrival timestamp of the PUBLISH.
      * <p>
      * For an incoming PUBLISH message the timestamp represents the moment when the message arrived at the broker.
+     * <p>
      * For a message created via the Extension SDK the timestamp represents the moment when the message is passed to
      * the PublishService.
      * <p>

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
@@ -168,9 +168,10 @@ public interface PublishPacket {
      * The arrival timestamp of the PUBLISH.
      * <p>
      * For an incoming PUBLISH message the timestamp is set to the moment that the message arrived at the broker.
-     * For a message created via the Extension SDK the timestamp is set to the moment that the message is passed to PublishService.
+     * For a message created via the Extension SDK the timestamp is set to the moment that the message is passed to
+     * PublishService.
      * <p>
-     * The returned timestamp is a UNIX timestamp since midnight, January 1, 1970 UTC in milliseconds
+     * The returned timestamp is a UNIX timestamp since midnight, January 1, 1970 UTC in milliseconds.
      *
      * @return The timestamp.
      * @since 4.4.0, CE 2020.4


### PR DESCRIPTION
**Motivation**
Make the publish arrival timestamp accessable from the sdk
