### PR TITLE
[4.7] ID3341: Wrong Session Expiry Value in ConnectInterceptor in SDK

### DIFF
--- a/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
@@ -94,6 +94,15 @@ public interface ConnectPacket {
     long getSessionExpiryInterval();
 
     /**
+     * A flag that signifies whether the session expiry interval was overridden by the MaxSessionExpiryInterval
+     * configuration value.
+     *
+     * @return A flag that shows whether the session expiry interval was overridden.
+     * @since 4.5.0, CE 2022.1
+     */
+    boolean getSessionExpiryOverridden();
+
+    /**
      * An interval in seconds in which the client has to send any MQTT control packet, so that HiveMQ doesn't end the
      * connection.
      *

--- a/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiableConnectPacket.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiableConnectPacket.java
@@ -94,6 +94,14 @@ public interface ModifiableConnectPacket extends ConnectPacket {
     void setSessionExpiryInterval(long expiryInterval);
 
     /**
+     * Set whether the session expiry interval was overridden.
+     *
+     * @param sessionExpiryOverridden The new value of flag that captures whether the sesson expiry was overriden.
+     * @since 4.5.0, CE 2022.1
+     */
+    void setSessionExpiryOverridden(boolean sessionExpiryOverridden);
+
+    /**
      * Set the keep alive.
      *
      * @param keepAlive The new keep alive for the CONNECT.


### PR DESCRIPTION
**Motivation**

Enable overriding session expiry interval on decoding stage of CONNECT message.

**Changes**

Moves information about the session expiry interval being overridden to connect packet and modifiable connect packet.