### PR TITLE
Add overload authenticateSuccessfully of SimpleAuthOutput with parameter to clear auth passws after authentication

### DIFF
--- a/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SimpleAuthOutput.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SimpleAuthOutput.java
@@ -75,6 +75,20 @@ public interface SimpleAuthOutput extends AsyncOutput<SimpleAuthOutput> {
     void authenticateSuccessfully();
 
     /**
+     * Successfully authenticates the client.
+     * <p>
+     * A CONNACK packet with reason code {@link ConnackReasonCode#SUCCESS SUCCESS} is sent to the client.
+     * <p>
+     * This is a final decision, authenticators of the next extensions (with lower priority) are not called.
+     *
+     * @param clearPasswordAfterAuth defines if the password will be cleared after authentication. Default is false
+     * @throws UnsupportedOperationException When authenticateSuccessfully, failAuthentication or nextExtensionOrDefault
+     *                                       has already been called.
+     * @since 4.30.0, CE 2019.1
+     */
+    void authenticateSuccessfully(boolean clearPasswordAfterAuth);
+
+    /**
      * Fails the authentication of the client.
      * <p>
      * A CONNACK packet with reason code {@link ConnackReasonCode#NOT_AUTHORIZED NOT_AUTHORIZED} and reason string


### PR DESCRIPTION
card https://hivemq.kanbanize.com/ctrl_board/4/cards/26231/details/
https://hivemq.kanbanize.com/ctrl_board/4/cards/27287/details/

siblings: https://github.com/hivemq/hivemq-enterprise-security-extension/pull/2943 https://github.com/hivemq/hivemq-extension-sdk/pull/772
