### PR TITLE
[428] Add overload SimpleAuthOutput.authenticateSuccessfully with boolean parameter to clear auth passwords after authentication

### DIFF
--- a/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SimpleAuthOutput.java
+++ b/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SimpleAuthOutput.java
@@ -75,6 +75,20 @@ public interface SimpleAuthOutput extends AsyncOutput<SimpleAuthOutput> {
     void authenticateSuccessfully();
 
     /**
+     * Successfully authenticates the client.
+     * <p>
+     * A CONNACK packet with reason code {@link ConnackReasonCode#SUCCESS SUCCESS} is sent to the client.
+     * <p>
+     * This is a final decision, authenticators of the next extensions (with lower priority) are not called.
+     *
+     * @param clearPasswordAfterAuth Defines if the password will be cleared after authentication.
+     * @throws UnsupportedOperationException When authenticateSuccessfully, failAuthentication or nextExtensionOrDefault
+     *                                       has already been called.
+     * @since 4.34.0, 4.28.8 CE 2024.8
+     */
+    void authenticateSuccessfully(boolean clearPasswordAfterAuth);
+
+    /**
      * Fails the authentication of the client.
      * <p>
      * A CONNACK packet with reason code {@link ConnackReasonCode#NOT_AUTHORIZED NOT_AUTHORIZED} and reason string


### PR DESCRIPTION
Card: https://hivemq.kanbanize.com/ctrl_board/4/cards/27287/details/
Related card: https://hivemq.kanbanize.com/ctrl_board/4/cards/26231/details/