### PR TITLE
[LATEST] PLATFORM: Upgrade toolchain to Java 25

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,9 @@ jobs:
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: |
+            21
+            25
           cache: gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,10 +74,16 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(25)
     }
     withJavadocJar()
     withSourcesJar()
+}
+
+tasks.compileJava {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 tasks.withType<Jar>().configureEach {


### PR DESCRIPTION
Upgrade the build toolchain to Java 25. Compile target stays at Java 11 via a compilerFor override; the 11 to 21 bump is deferred to the next-lts epic branch and can then be flipped without further config changes.

Part of INT-8.