### PR TITLE
[4.28] PLATFORM: Upgrade toolchain to Java 21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,10 +73,16 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(21)
     }
     withJavadocJar()
     withSourcesJar()
+}
+
+tasks.compileJava {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
 }
 
 tasks.withType<Jar>().configureEach {


### PR DESCRIPTION
Upgrade the build/test toolchain to Java 21 and pin the compile target to Java 11 via a compilerFor override, keeping the 4.28 LTS artifacts Java 11 compatible.

Part of INT-8.